### PR TITLE
feat: User creation API + Docker setup + JPA integration

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,26 @@
+-- Create schema
+CREATE SCHEMA IF NOT EXISTS "task-management-system";
+
+-- Create enum type for user roles
+DO $$ BEGIN
+    CREATE TYPE "user_role" AS ENUM ('SUPERADMIN', 'ADMIN', 'USER');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Create user table
+CREATE TABLE IF NOT EXISTS "task-management-system"."user" (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    role_id "user_role" NOT NULL,
+    created_at BIGINT,
+    created_by UUID,
+    updated_at BIGINT,
+    updated_by UUID
+);
+
+-- Optional: Add unique constraint on email if required
+-- ALTER TABLE "task-management-system"."user" ADD CONSTRAINT unique_email UNIQUE (email);
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   app:
     build:
@@ -22,9 +23,9 @@ services:
     depends_on:
       - db
     environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
-      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
-      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       SERVER_PORT: ${SERVER_PORT}
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"

--- a/src/main/java/com/example/task_management_system/apis/HealthController.java
+++ b/src/main/java/com/example/task_management_system/apis/HealthController.java
@@ -3,7 +3,6 @@ package com.example.task_management_system.apis;
 
 import com.example.task_management_system.models.response.health.CheckHealthResponse;
 import com.example.task_management_system.service.HealthService;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,5 +32,4 @@ public class HealthController {
             return new ResponseEntity<>(new CheckHealthResponse(), HttpStatus.BAD_REQUEST);
         }
     }
-
 }

--- a/src/main/java/com/example/task_management_system/apis/UserController.java
+++ b/src/main/java/com/example/task_management_system/apis/UserController.java
@@ -1,0 +1,33 @@
+package com.example.task_management_system.apis;
+
+import com.example.task_management_system.models.request.CreateUserRequest;
+import com.example.task_management_system.models.response.user.CreateUserResponse;
+import com.example.task_management_system.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/taskmanagement/v1")
+public class UserController {
+    private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/create")
+    public ResponseEntity<CreateUserResponse> createUser (@RequestBody CreateUserRequest userRequest){
+        logger.info("UserController::createUser: Method Triggered!");
+        try{
+            CreateUserResponse createUserResponse = userService.createUser(userRequest);
+            logger.info("UserController::createUser: User create successfully with info - {}", createUserResponse);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createUserResponse);
+        }catch (Exception e) {
+            logger.error("UserController::createUser: Exception occurred - {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+}

--- a/src/main/java/com/example/task_management_system/models/request/CreateUserRequest.java
+++ b/src/main/java/com/example/task_management_system/models/request/CreateUserRequest.java
@@ -1,0 +1,12 @@
+package com.example.task_management_system.models.request;
+
+import com.example.task_management_system.repository.postgres.enums.UserRole;
+import lombok.Data;
+
+@Data
+public class CreateUserRequest {
+    private String firstName;
+    private String lastName;
+    private String email;
+    private UserRole roleId;
+}

--- a/src/main/java/com/example/task_management_system/models/response/user/CreateUserResponse.java
+++ b/src/main/java/com/example/task_management_system/models/response/user/CreateUserResponse.java
@@ -1,0 +1,16 @@
+package com.example.task_management_system.models.response.user;
+
+import com.example.task_management_system.repository.postgres.schema.User;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@Builder
+public class CreateUserResponse {
+    private User user;
+    private String message;
+}

--- a/src/main/java/com/example/task_management_system/repository/postgres/ro/UserRepositoryRO.java
+++ b/src/main/java/com/example/task_management_system/repository/postgres/ro/UserRepositoryRO.java
@@ -1,0 +1,4 @@
+package com.example.task_management_system.repository.postgres.ro;
+
+public interface UserRepositoryRO {
+}

--- a/src/main/java/com/example/task_management_system/repository/postgres/rw/UserRepositoryRW.java
+++ b/src/main/java/com/example/task_management_system/repository/postgres/rw/UserRepositoryRW.java
@@ -1,0 +1,7 @@
+package com.example.task_management_system.repository.postgres.rw;
+
+import com.example.task_management_system.repository.postgres.schema.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepositoryRW extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/task_management_system/repository/postgres/schema/AbstractEntity.java
+++ b/src/main/java/com/example/task_management_system/repository/postgres/schema/AbstractEntity.java
@@ -5,7 +5,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 
 @Data

--- a/src/main/java/com/example/task_management_system/repository/postgres/schema/User.java
+++ b/src/main/java/com/example/task_management_system/repository/postgres/schema/User.java
@@ -33,4 +33,20 @@ public class User extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "role_id", nullable = false)
     private UserRole roleId;
+
+    @Column(name="password")
+    private String password;
+
+    @Column(name="is_active")
+    private String isActive;
+
+// TODO: Might be helpful later (Take a look at how to utilize it later)
+//    private User create(User userRequest){
+//        return User.builder()
+//                .roleId(userRequest.roleId)
+//                .email(userRequest.email)
+//                .firstName(userRequest.firstName)
+//                .lastName(userRequest.lastName)
+//                .build();
+//    }
 }

--- a/src/main/java/com/example/task_management_system/service/HealthService.java
+++ b/src/main/java/com/example/task_management_system/service/HealthService.java
@@ -1,6 +1,5 @@
 package com.example.task_management_system.service;
 
-import com.example.task_management_system.apis.HealthController;
 import com.example.task_management_system.models.response.health.CheckHealthResponse;
 import com.example.task_management_system.repository.postgres.ro.HealthRepositoryRO;
 import com.example.task_management_system.repository.postgres.schema.User;

--- a/src/main/java/com/example/task_management_system/service/UserService.java
+++ b/src/main/java/com/example/task_management_system/service/UserService.java
@@ -1,29 +1,35 @@
 package com.example.task_management_system.service;
 
-import com.example.task_management_system.models.response.health.CheckHealthResponse;
-import com.example.task_management_system.repository.postgres.enums.UserRole;
-import com.example.task_management_system.repository.postgres.ro.HealthRepositoryRO;
+import com.example.task_management_system.models.request.CreateUserRequest;
+import com.example.task_management_system.models.response.user.CreateUserResponse;
+import com.example.task_management_system.repository.postgres.rw.UserRepositoryRW;
 import com.example.task_management_system.repository.postgres.schema.User;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 
+@Service
 //TODO: Work pending start from scratch.
 public class UserService {
 
     @Autowired
-    HealthRepositoryRO healthRepositoryRO;
-    public CheckHealthResponse createUser(){
+    UserRepositoryRW userRepositoryRW;
+    public CreateUserResponse createUser(CreateUserRequest userRequest){
         User user = User.builder()
-                .roleId(UserRole.USER)
-                .email("lkdjalfkj")
-                .firstName("djnalg")
-                .lastName("lkdajg")
+                .firstName(userRequest.getFirstName())
+                .lastName(userRequest.getLastName())
+                .email(userRequest.getEmail())
+                .roleId(userRequest.getRoleId())
                 .build();
+        user.create(); // Set createdAt and updatedAt timestamps
 
-        healthRepositoryRO.save(user);
+        //JPA Save method
+        userRepositoryRW.save(user);
 
-        return CheckHealthResponse.builder()
-                .status("SUCCESSFULL")
+        return CreateUserResponse.builder()
+                .user(user)
                 .message("Connection Establised")
                 .build();
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,12 +1,11 @@
 server:
-  port: 8081
+  port: ${SERVER_PORT}
 
 spring:
   application:
     name: task-management-system
   datasource:
-    url: ${APPLICATION_DATASOURCE_LOCAL_URL}
-    basePackages: ${DATASOURCE_LOCAL_BASEPACKAGES}
+    url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:


### PR DESCRIPTION
# feat: User creation API + Docker setup + JPA integration

## Summary
- Implemented `createUser` API in `UserController` and `UserService`.  
- Configured `User` entity with JPA and PostgreSQL schema.  
- Added Docker setup for local development:  
  - Postgres container running on specified port.  
  - Application container connected to Postgres.  
- Fixed datasource and application properties for seamless local integration.  
- Verified API endpoint `/taskmanagement/v1/create` works with JSON requests.  

## Changes
- `UserController` & `UserService` implemented for user creation.  
- `User` entity mapped with JPA annotations.  
- `application.yaml` configured for local Docker Postgres.  
- Docker-compose file updated for app + database containers.  
- Tested API with `curl` request; user creation working end-to-end.  

## Next Steps
- Implement additional user management APIs (update, delete, fetch).  
- Add unit/integration tests for user creation API.
